### PR TITLE
alternative (easier?) way to define datasets

### DIFF
--- a/MDAnalysisData/__init__.py
+++ b/MDAnalysisData/__init__.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 __all__ = ['datasets']
 
 from . import datasets
-
+from .base import fetch, DATASET_NAMES
 
 
 

--- a/MDAnalysisData/adk_equilibrium.py
+++ b/MDAnalysisData/adk_equilibrium.py
@@ -5,88 +5,32 @@
 https://figshare.com/articles/Molecular_dynamics_trajectory_for_benchmarking_MDAnalysis/5108170/1
 """
 
-from os.path import dirname, exists, join
-from os import makedirs, remove
-import codecs
-
 import logging
 
-from .base import get_data_home
-from .base import _fetch_remote
-from .base import RemoteFileMetadata
-from .base import Bunch
+from .base import RemoteFileMetadata, Dataset
 
-NAME = "adk_equilibrium"
-DESCRIPTION = "adk_equilibrium.rst"
-# The original data can be found at the figshare URL.
-# The SHA256 checksum of the zip file changes with every download so we
-# cannot check its checksum. Instead we download individual files.
-# separately. The keys of this dict are also going to be the keys in the
-# Bunch that is returned.
-ARCHIVE = {
-    'topology': RemoteFileMetadata(
-        filename='adk4AKE.psf',
-        url='https://ndownloader.figshare.com/files/8672230',
-        checksum='1aa947d58fb41b6805dc1e7be4dbe65c6a8f4690f0bd7fc2ae03e7bd437085f4',
-    ),
-    'trajectory':  RemoteFileMetadata(
-        filename='1ake_007-nowater-core-dt240ps.dcd',
-        url='https://ndownloader.figshare.com/files/8672074',
-        checksum='598fcbcfcc425f6eafbe9997238320fcacc6a4613ecce061e1521732bab734bf',
-    ),
-}
 
 logger = logging.getLogger(__name__)
 
 
-def fetch_adk_equilibrium(data_home=None, download_if_missing=True):
-    """Load the AdK 1us equilibrium trajectory (without water)
+class ADK_Equilibrium(Dataset):
+    NAME = "adk_equilibrium"
+    DESCRIPTION = "adk_equilibrium.rst"
 
-    Parameters
-    ----------
-    data_home : optional, default: None
-        Specify another download and cache folder for the datasets. By default
-        all MDAnalysisData data is stored in '~/MDAnalysis_data' subfolders.
-        This dataset is stored in ``<data_home>/adk_equilibrium``.
-    download_if_missing : optional, default=True
-        If ``False``, raise a :exc:`IOError` if the data is not locally available
-        instead of trying to download the data from the source site.
-
-    Returns
-    -------
-    dataset : dict-like object with the following attributes:
-    dataset.topology : filename
-        Filename of the topology file
-    dataset.trajectory : filename
-        Filename of the trajectory file
-    dataset.DESCR : string
-        Description of the trajectory.
-
-
-    See :ref:`adk-equilibrium-dataset` for description.
-    """
-    name = NAME
-    data_location = join(get_data_home(data_home=data_home),
-                         name)
-    if not exists(data_location):
-        makedirs(data_location)
-
-    records = Bunch()
-    for file_type, meta in ARCHIVE.items():
-        local_path = join(data_location, meta.filename)
-        records[file_type] = local_path
-
-        if not exists(local_path):
-            if not download_if_missing:
-                raise IOError("Data {0}={1} not found and `download_if_missing` is "
-                              "False".format(file_type, local_path))
-            logger.info("Downloading {0}: {1} -> {2}...".format(
-                file_type, meta.url, local_path))
-            archive_path = _fetch_remote(meta, dirname=data_location)
-
-    module_path = dirname(__file__)
-    with codecs.open(join(module_path, 'descr', DESCRIPTION),
-                     encoding="utf-8") as dfile:
-        records.DESCR = dfile.read()
-
-    return records
+    # The original data can be found at the figshare URL.
+    # The SHA256 checksum of the zip file changes with every download so we
+    # cannot check its checksum. Instead we download individual files.
+    # separately. The keys of this dict are also going to be the keys in the
+    # Bunch that is returned.
+    ARCHIVE = {
+        'topology': RemoteFileMetadata(
+            filename='adk4AKE.psf',
+            url='https://ndownloader.figshare.com/files/8672230',
+            checksum='1aa947d58fb41b6805dc1e7be4dbe65c6a8f4690f0bd7fc2ae03e7bd437085f4',
+        ),
+        'trajectory':  RemoteFileMetadata(
+            filename='1ake_007-nowater-core-dt240ps.dcd',
+            url='https://ndownloader.figshare.com/files/8672074',
+            checksum='598fcbcfcc425f6eafbe9997238320fcacc6a4613ecce061e1521732bab734bf',
+        ),
+    }

--- a/MDAnalysisData/datasets.py
+++ b/MDAnalysisData/datasets.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 
 
 from .base import get_data_home, clear_data_home
-from .adk_equilibrium import fetch_adk_equilibrium
+from . import adk_equilibrium
 from .adk_transitions import (fetch_adk_transitions_DIMS,
                               fetch_adk_transitions_FRODA)
 from .ifabp_water import fetch_ifabp_water
@@ -16,7 +16,6 @@ from .vesicles import fetch_vesicle_lib
 __all__ = [
     'get_data_home',
     'clear_data_home',
-    'fetch_adk_equilibrium',
     'fetch_adk_transitions_DIMS',
     'fetch_adk_transitions_FRODA',
     'fetch_ifabp_water',


### PR DESCRIPTION
@orbeckst what do you think about this?  I was looking at how to write tests for this package, and with every single dataset implementing how it should be downloaded, there was a lot of room for potential errors.  Instead if we define a template for how a dataset should look, we can have the logic of how this is retrieved in a centralised location.

It takes ideas from how we auto-register Readers in MDAnalysis, so Datasets are added to a list of available datasets once defined.