### PR TITLE
Fix zipped egg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ python:
 branches:
   only:
     - master
-
-env:
-  global:
-    - secure:
     
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install --upgrade sphinx sphinx-sitemap; fi
@@ -27,7 +23,7 @@ after_success:
 
 deploy:
   # stuff related to deploying to gh-pages
-  # GUTHUB_TOKEN is set in Travis-CI settings (@orbeckst)
+  # GITHUB_TOKEN is set in Travis-CI settings (@orbeckst)
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixes
 - fixed description of 'AdK equilibrium' dataset
-
+- fixed loading descriptions from zipped eggs (#12)
 
 ### Added
 - new `fetch_nhaa_equilibrium()` to get the NhaA trajectory from

--- a/MDAnalysisData/adk_equilibrium.py
+++ b/MDAnalysisData/adk_equilibrium.py
@@ -7,12 +7,11 @@ https://figshare.com/articles/Molecular_dynamics_trajectory_for_benchmarking_MDA
 
 from os.path import dirname, exists, join
 from os import makedirs, remove
-import codecs
 
 import logging
 
 from .base import get_data_home
-from .base import _fetch_remote
+from .base import _fetch_remote, _read_description
 from .base import RemoteFileMetadata
 from .base import Bunch
 
@@ -84,9 +83,6 @@ def fetch_adk_equilibrium(data_home=None, download_if_missing=True):
                 file_type, meta.url, local_path))
             archive_path = _fetch_remote(meta, dirname=data_location)
 
-    module_path = dirname(__file__)
-    with codecs.open(join(module_path, 'descr', DESCRIPTION),
-                     encoding="utf-8") as dfile:
-        records.DESCR = dfile.read()
+    records.DESCR = _read_description(DESCRIPTION)
 
     return records

--- a/MDAnalysisData/adk_transitions.py
+++ b/MDAnalysisData/adk_transitions.py
@@ -8,16 +8,16 @@ https://figshare.com/articles/Simulated_trajectory_ensembles_for_the_closed-to-o
 
 from os.path import dirname, exists, join
 from os import makedirs, remove
-import codecs
 import tarfile
 import glob
 
 import logging
 
 from .base import get_data_home
-from .base import _fetch_remote
+from .base import _fetch_remote, _read_description
 from .base import RemoteFileMetadata
 from .base import Bunch
+
 
 METADATA = {
     'DIMS': {
@@ -191,9 +191,6 @@ def _fetch_adk_transitions(metadata, data_home=None, download_if_missing=True):
                                trajectory_pattern, len(records.trajectories),
                                records.N_trajectories))
 
-    module_path = dirname(__file__)
-    with codecs.open(join(module_path, 'descr', metadata['DESCRIPTION']),
-                     encoding="utf-8") as dfile:
-        records.DESCR = dfile.read()
+    records.DESCR = _read_description(DESCRIPTION)
 
     return records

--- a/MDAnalysisData/base.py
+++ b/MDAnalysisData/base.py
@@ -34,7 +34,7 @@ from collections import namedtuple
 from os import environ, listdir, makedirs
 from os.path import dirname, exists, expanduser, isdir, join, splitext
 import hashlib
-
+from pkg_resources import resource_string
 
 
 class Bunch(dict):
@@ -179,3 +179,26 @@ def _fetch_remote(remote, dirname=None):
                       "file may be corrupted.".format(file_path, checksum,
                                                       remote.checksum))
     return file_path
+
+
+def _read_description(filename, description_dir='descr'):
+    """Read the description from restructured text file `descr`.
+
+    Arguments
+    ---------
+    filename : str
+        name of the description file under the ``descr`` directory
+
+    Note
+    ----
+    All description files are supposed to be stored in the directory
+    ``description_dir`="descr"` that lives in the same directory as
+    the :mod:`MDAnalysisData.base` module file. All descriptions are
+    assumed to be in restructured text format and in UTF-8 encoding.
+    """
+    # The descr directory should be in the same directory as this file base.py.
+    # `resource_string` returns bytes, which we need to decode to UTF-8
+    DESCR = resource_string(__name__,
+                            '{}/{}'.format(description_dir, filename)
+                           ).decode("utf-8")
+    return DESCR

--- a/MDAnalysisData/ifabp_water.py
+++ b/MDAnalysisData/ifabp_water.py
@@ -7,12 +7,11 @@ https://figshare.com/articles/Molecular_dynamics_trajectory_of_I-FABP_for_testin
 
 from os.path import dirname, exists, join
 from os import makedirs, remove
-import codecs
 
 import logging
 
 from .base import get_data_home
-from .base import _fetch_remote
+from .base import _fetch_remote, _read_description
 from .base import RemoteFileMetadata
 from .base import Bunch
 
@@ -93,9 +92,6 @@ def fetch_ifabp_water(data_home=None, download_if_missing=True):
                 file_type, meta.url, local_path))
             archive_path = _fetch_remote(meta, dirname=data_location)
 
-    module_path = dirname(__file__)
-    with codecs.open(join(module_path, 'descr', DESCRIPTION),
-                     encoding="utf-8") as dfile:
-        records.DESCR = dfile.read()
+    records.DESCR = _read_description(DESCRIPTION)
 
     return records

--- a/MDAnalysisData/nhaa_equilibrium.py
+++ b/MDAnalysisData/nhaa_equilibrium.py
@@ -12,7 +12,7 @@ import codecs
 import logging
 
 from .base import get_data_home
-from .base import _fetch_remote
+from .base import _fetch_remote, _read_description
 from .base import RemoteFileMetadata
 from .base import Bunch
 
@@ -84,9 +84,6 @@ def fetch_nhaa_equilibrium(data_home=None, download_if_missing=True):
                 file_type, meta.url, local_path))
             archive_path = _fetch_remote(meta, dirname=data_location)
 
-    module_path = dirname(__file__)
-    with codecs.open(join(module_path, 'descr', DESCRIPTION),
-                     encoding="utf-8") as dfile:
-        records.DESCR = dfile.read()
+    records.DESCR = _read_description(DESCRIPTION)
 
     return records

--- a/MDAnalysisData/vesicles.py
+++ b/MDAnalysisData/vesicles.py
@@ -8,13 +8,12 @@ https://figshare.com/articles/Large_System_Vesicle_Benchmark_Library/3406708
 
 from os.path import dirname, exists, join
 from os import makedirs, remove
-import codecs
 import tarfile
 
 import logging
 
 from .base import get_data_home
-from .base import _fetch_remote
+from .base import _fetch_remote, _read_description
 from .base import RemoteFileMetadata
 from .base import Bunch
 
@@ -107,9 +106,6 @@ def fetch_vesicle_lib(data_home=None, download_if_missing=True):
                                len(records.structures),
                                records.N_structures))
 
-    module_path = dirname(__file__)
-    with codecs.open(join(module_path, 'descr', metadata['DESCRIPTION']),
-                     encoding="utf-8") as dfile:
-        records.DESCR = dfile.read()
+    records.DESCR = _read_description(DESCRIPTION)
 
     return records

--- a/docs/helpers.rst
+++ b/docs/helpers.rst
@@ -35,4 +35,6 @@ functions in your code.
 
 .. autofunction:: _fetch_remote		  
 
+.. autofunction:: _read_description
+
 		  


### PR DESCRIPTION
fix #12 

- use read_stream from https://setuptools.readthedocs.io/en/latest/pkg_resources.html to extract descriptions, even when installed as zipped eggs
- added new `base._read_description()` to simplify descr reading

Hopefully the utf-8 decoding works on Python 2 and Python 3 (only Python 3 tested locally... need #6!)