### PR TITLE
Disallow cron codecov calls

### DIFF
--- a/.github/workflows/gh-ci.yml
+++ b/.github/workflows/gh-ci.yml
@@ -41,7 +41,7 @@ jobs:
         fetch-depth: 0
 
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -66,7 +66,8 @@ jobs:
         pytest -v --cov=MDAnalysisData --cov-report=xml --color=yes MDAnalysisData/tests
 
     - name: Codecov
-      uses: codecov/codecov-action@v2
+      if: github.event_name != 'schedule'
+      uses: codecov/codecov-action@v4
       with:
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Avoids actions failing when pushing the same codecov results over and over again.